### PR TITLE
docs(cn): translate content/warnings/invalid-aria-prop.md into Chinese

### DIFF
--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -1,11 +1,14 @@
 ---
-title: Invalid ARIA Prop Warning
+title: 非法 ARIA Prop 警告
 layout: single
 permalink: warnings/invalid-aria-prop.html
 ---
 
-The invalid-aria-prop warning will fire if you attempt to render a DOM element with an aria-* prop that does not exist in the Web Accessibility Initiative (WAI) Accessible Rich Internet Application (ARIA) [specification](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties).
+invalid-aria-prop 警告出现在：当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI-ARIA [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) 中时。
 
-1. If you feel that you are using a valid prop, check the spelling carefully. `aria-labelledby` and `aria-activedescendant` are often misspelled.
+（WAI：Web Accessibility Initiative，Web 无障碍计划）  
+（ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序）
 
-2. React does not yet recognize the attribute you specified. This will likely be fixed in a future version of React. However, React currently strips all unknown attributes, so specifying them in your React app will not cause them to be rendered
+1. 如果你认为你使用的是合法的属性，仔细检查拼写。`aria-labelledby` 和 `aria-activedescendant` 常常会被拼错。
+
+2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，当前的 React 会去除所有未知属性，因此在 React 应用中指定它们不会使得它们被渲染。

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -1,5 +1,5 @@
 ---
-title: 非法 ARIA Prop 警告
+title: 警告：非法的 ARIA Prop
 layout: single
 permalink: warnings/invalid-aria-prop.html
 ---

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -10,7 +10,7 @@ permalink: warnings/invalid-aria-prop.html
 
 2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，React 目前会去除所有未知属性，因此即使在 React 应用中指定这些属性也无法使它们渲染。
 
-### 译注：
+**译注：**
  
 <a name="note1"></a> [1] WAI：Web Accessibility Initiative，Web 无障碍计划<br>
 <a name="note2"></a> [2] ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -4,13 +4,13 @@ layout: single
 permalink: warnings/invalid-aria-prop.html
 ---
 
-当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI<sup>①</sup>-ARIA<sup>②</sup> [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)中时，会出现 invalid-aria-prop 警告。
+当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI<sup><a href="#note1">[1]</a></sup>-ARIA<sup><a href="#note2">[2]</a></sup> [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)中时，会出现 invalid-aria-prop 警告。
 
 1. 如果你认为你使用的是合法的属性，仔细检查拼写。`aria-labelledby` 和 `aria-activedescendant` 常常会被拼错。
 
 2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，React 目前会去除所有未知属性，因此即使在 React 应用中指定这些属性也无法使它们渲染。
 
-> 译注：
-> 
-> ① WAI：Web Accessibility Initiative，Web 无障碍计划<br>
-> ② ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序
+### 译注：
+ 
+<a name="note1"></a> [1] WAI：Web Accessibility Initiative，Web 无障碍计划<br>
+<a name="note2"></a> [2] ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -4,11 +4,11 @@ layout: single
 permalink: warnings/invalid-aria-prop.html
 ---
 
-invalid-aria-prop 警告出现在：当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI-ARIA [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) 中时。
+当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI-ARIA [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) 中时，会出现 invalid-aria-prop 警告。
 
 （WAI：Web Accessibility Initiative，Web 无障碍计划）  
 （ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序）
 
 1. 如果你认为你使用的是合法的属性，仔细检查拼写。`aria-labelledby` 和 `aria-activedescendant` 常常会被拼错。
 
-2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，当前的 React 会去除所有未知属性，因此在 React 应用中指定它们不会使得它们被渲染。
+2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，React 目前会去除所有未知属性，因此即使在 React 应用中指定这些属性也无法使它们渲染。

--- a/content/warnings/invalid-aria-prop.md
+++ b/content/warnings/invalid-aria-prop.md
@@ -4,11 +4,13 @@ layout: single
 permalink: warnings/invalid-aria-prop.html
 ---
 
-当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI-ARIA [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties) 中时，会出现 invalid-aria-prop 警告。
-
-（WAI：Web Accessibility Initiative，Web 无障碍计划）  
-（ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序）
+当你试图渲染一个 DOM 元素，并且它的 aria-* 属性不存在于 WAI<sup>①</sup>-ARIA<sup>②</sup> [规范](https://www.w3.org/TR/wai-aria-1.1/#states_and_properties)中时，会出现 invalid-aria-prop 警告。
 
 1. 如果你认为你使用的是合法的属性，仔细检查拼写。`aria-labelledby` 和 `aria-activedescendant` 常常会被拼错。
 
 2. React 还无法识别你指定的属性。这可能会在 React 的未来版本中被修复。但是，React 目前会去除所有未知属性，因此即使在 React 应用中指定这些属性也无法使它们渲染。
+
+> 译注：
+> 
+> ① WAI：Web Accessibility Initiative，Web 无障碍计划<br>
+> ② ARIA：Accessible Rich Internet Application，无障碍丰富互联网应用程序


### PR DESCRIPTION
https://stackblitz.com/edit/react-invalid-aria-prop
warning 重现

因为单词缩写太长 做了一些结构性调整（参考人家俄文的调整…）