### PR TITLE
fix(docs):  modify the comment for content/docs/handling-events.md

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -101,7 +101,7 @@ ReactDOM.render(
 
 ```js{2-6}
 class LoggingButton extends React.Component {
-  // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的。
+  // 此语法确保 `handleClick` 内的 `this` 已被绑定。
   // 注意: 这是 *实验性* 语法。
   handleClick = () => {
     console.log('this is:', this);
@@ -128,7 +128,7 @@ class LoggingButton extends React.Component {
   }
 
   render() {
-    // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的。
+    // 此语法确保 `handleClick` 内的 `this` 已被绑定。
     return (
       <button onClick={(e) => this.handleClick(e)}>
         Click me
@@ -152,4 +152,3 @@ class LoggingButton extends React.Component {
 上述两种方式是等价的，分别通过[箭头函数](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)和 [`Function.prototype.bind`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Function/bind) 来实现。
 
 在这两种情况下，React 的事件对象 `e` 会被作为第二个参数传递。如果通过箭头函数的方式，事件对象必须显式的进行传递，而通过 `bind` 的方式，事件对象以及更多的参数将会被隐式的进行传递。
-

--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -101,7 +101,7 @@ ReactDOM.render(
 
 ```js{2-6}
 class LoggingButton extends React.Component {
-  // 这种语法确保 `this` 绑定在 `handleClick` 内。
+  // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的。
   // 注意: 这是 *实验性* 语法。
   handleClick = () => {
     console.log('this is:', this);
@@ -128,7 +128,7 @@ class LoggingButton extends React.Component {
   }
 
   render() {
-    // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的
+    // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的。
     return (
       <button onClick={(e) => this.handleClick(e)}>
         Click me

--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -128,7 +128,7 @@ class LoggingButton extends React.Component {
   }
 
   render() {
-    // 这种语法确保 `this` 绑定在 `handleClick` 内。
+    // 这种语法确保 `handleClick` 内 `this` 是已经被绑定的
     return (
       <button onClick={(e) => this.handleClick(e)}>
         Click me


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

`this` 绑定在 `handleClick` 内听起来很奇怪，通常来说 `this` 被绑定指的是上下文绑定了（例如这里应该说绑定了当前 `class`）。
