### PR TITLE
fix(docs): translate error in jsx-in-depth

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -432,7 +432,7 @@ function ListOfTenThings() {
 </div>
 ```
 
-值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 0，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，虽然 `props.messages` 是空数组时长度为 `0`，但 `<MessageList />` 仍然会被渲染：
+值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 `0`，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，因为当 `props.messages` 是空数组时，`0` 仍然会被渲染：
 
 ```js{2}
 <div>


### PR DESCRIPTION
In English:
For example, this code will not behave as you might expect because **0 will be printed** when props.messages is an empty array:

是 **0会被渲染** 而不是 ~~\<MessageList /\>会被渲染~~



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
