### PR TITLE
docs(cn): translate default text for CodePen samples links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,7 +59,7 @@ module.exports = {
           {
             resolve: 'gatsby-remark-code-repls',
             options: {
-              defaultText: '<b>Try it on CodePen</b>',
+              defaultText: '<b>在 CodePen 上尝试</b>',
               directory: `${__dirname}/examples/`,
               externals: [
                 `//unpkg.com/react/umd/react.development.js`,


### PR DESCRIPTION
文档中以 `[](codepen://...)` 形式出现的 CodePen 链接的默认文本由插件 `gatsby-remark-code-repls` 设置。
所以，我认为应该将 `gatsby-config.js` 中的默认文本翻译为汉语，文档中的链接文本按照英文原文留空即可。

此外，如果使用强调语法修饰此类型链接的文本（如 `[**文本**](codepen://...)`），Gatsby 会将其错误的渲染为 `undefined`（如[非受控组件](https://zh-hans.reactjs.org/docs/uncontrolled-components.html)页面底部的链接）。