### PR TITLE
docs(cn): fix punctuation error in content/docs/hooks-state.md

### DIFF
--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -98,7 +98,7 @@ function Example() {
 }
 ```
 
-**Hook 是什么？** Hook 是一个特殊的函数，它可以让你“钩入”React 的特性。例如，`useState` 是允许你在 React 函数组件中添加 state 的 Hook。稍后我们将学习其他 Hook。
+**Hook 是什么？** Hook 是一个特殊的函数，它可以让你“钩入” React 的特性。例如，`useState` 是允许你在 React 函数组件中添加 state 的 Hook。稍后我们将学习其他 Hook。
 
 **什么时候我会用 Hook？** 如果你在编写函数组件并意识到需要向其添加一些 state，以前的做法是必须将其它转化为 class。现在你可以在现有的函数组件中使用 Hook。
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -98,7 +98,7 @@ function Example() {
 }
 ```
 
-**Hook 是什么？** Hook 是一个特殊的函数，它可以让你 `钩入` React 的特性。例如，`useState` 是允许你在 React 函数组件中添加 state 的 Hook。稍后我们将学习其他 Hook。
+**Hook 是什么？** Hook 是一个特殊的函数，它可以让你“钩入”React 的特性。例如，`useState` 是允许你在 React 函数组件中添加 state 的 Hook。稍后我们将学习其他 Hook。
 
 **什么时候我会用 Hook？** 如果你在编写函数组件并意识到需要向其添加一些 state，以前的做法是必须将其它转化为 class。现在你可以在现有的函数组件中使用 Hook。
 


### PR DESCRIPTION
原文是双引号 ”hook into“，不是代码 `hook into`。

The original words are "hook into", not `hook into`.


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
