### PR TITLE
docs(cn): fix the misleading function name in content/tutorial/tutorial.md

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -692,7 +692,7 @@ class Board extends React.Component {
 
 ### 判断出胜者 {#declaring-a-winner}
 
-至此我们就可以看出下一步会轮到哪位玩家，与此同时，我们还需要显示游戏的结果来判定游戏结束。拷贝如下 helper 函数并粘贴到文件底部：
+至此我们就可以看出下一步会轮到哪位玩家，与此同时，我们还需要显示游戏的结果来判定游戏结束。拷贝如下 calculateWinner 函数并粘贴到文件底部：
 
 ```javascript
 function calculateWinner(squares) {


### PR DESCRIPTION
replace helper with calculateWinner.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
