### PR TITLE
docs(cn): modify semantic errors in content/docs/hooks-faq.md

### DIFF
--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -399,7 +399,7 @@ function Example() {
 }
 ```
 
-如果你先点击「Show alert」然后增加计数器的计数，那这个 alert 会 **在你点击『Show alert』按钮时** 显示 `count` 变量。这避免了那些因为假设 props 和 state 没有改变的代码引起问题。
+如果你先点击「Show alert」然后增加计数器的计数，那这个 alert 会显示**在你点击『Show alert』按钮时**的 `count` 变量。这避免了那些因为假设 props 和 state 没有改变的代码引起问题。
 
 如果你刻意地想要从某些异步回调中读取 *最新的* state，你可以用 [一个 ref](/docs/hooks-faq.html#is-there-something-like-instance-variables) 来保存它，修改它，并从中读取。
 


### PR DESCRIPTION
语义不太对，原文是 the alert will show the count variable at the time you clicked the “Show alert” button.
意思是 alert 会显示点击按钮时的 count 变量，而不是「 alert 会 在你点击『Show alert』按钮时 显示 count 变量」



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
