### PR TITLE
docs(cn): fix word spell error in content/docs/state-and-lifecycle.md

### DIFF
--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -201,7 +201,7 @@ ReactDOM.render(
 
 当 `Clock` 组件第一次被渲染到 DOM 中的时候，就为其[设置一个计时器](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/setInterval)。这在 React 中被称为“挂载（mount）”。
 
-同时，当 DOM 中 `Clock` 组件被删除的时候，应该[清除计时器](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearInterval)。这在 React 中被称为“卸载（umount）”。
+同时，当 DOM 中 `Clock` 组件被删除的时候，应该[清除计时器](https://developer.mozilla.org/en-US/docs/Web/API/WindowTimers/clearInterval)。这在 React 中被称为“卸载（unmount）”。
 
 我们可以为 class 组件声明一些特殊的方法，当组件挂载或卸载时就会去执行这些方法：
 


### PR DESCRIPTION
卸载的单词应该是【unmount】，而不是【umount】。