### PR TITLE
docs(cn): update React.createContext in content/docs/context.md

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -117,7 +117,7 @@ const MyContext = React.createContext(defaultValue);
 
 创建一个 Context 对象。当 React 渲染一个订阅了这个 Context 对象的组件，这个组件会从组件树中离自身最近的那个匹配的 `Provider` 中读取到当前的 context 值。
 
-只有当组件所处的树中没有匹配到 Provider 时，其 `defaultValue` 参数**才**会生效。这有助于在不使用 Provider 包装组件的情况下对组件进行测试。注意：将 `undefined` 传递给 Provider 时，消费组件的 `defaultValue` 不会生效。
+**只有**当组件所处的树中没有匹配到 Provider 时，其 `defaultValue` 参数才会生效。这有助于在不使用 Provider 包装组件的情况下对组件进行测试。注意：将 `undefined` 传递给 Provider 的 value 时，消费组件的 `defaultValue` 不会生效。
 
 ### `Context.Provider` {#contextprovider}
 


### PR DESCRIPTION
按照原文（英文）的意思，只有将 `undefined` 的 value 传递给 Provider 时，消费 context 的组件的 defaultValue 才不会生效。
而翻译中没有提到 Provider 的 value，不够清楚。

![image](https://user-images.githubusercontent.com/10390004/62912584-6c003e00-bdbb-11e9-933a-0cbbe2ca5e87.png)


<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
