### PR TITLE
Variable reference error

### DIFF
--- a/content/docs/lifting-state-up.md
+++ b/content/docs/lifting-state-up.md
@@ -46,10 +46,10 @@ class Calculator extends React.Component {
       <fieldset>
         <legend>Enter temperature in Celsius:</legend>
         <input
-          value={temperature}
+          value={this.state.temperature}
           onChange={this.handleChange} />
         <BoilingVerdict
-          celsius={parseFloat(temperature)} />
+          celsius={parseFloat(this.state.temperature)} />
       </fieldset>
     );
   }


### PR DESCRIPTION
49nd line:  value={temperature}   modified to   value={this.state.temperature} 
52nd line: celsius={parseFloat(temperature)} />   modified to    celsius={parseFloat(this.state.temperature)} />



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
