### PR TITLE
docs(cn): fix word in examples/forwarding-refs/log-props-after.js

### DIFF
--- a/examples/forwarding-refs/log-props-after.js
+++ b/examples/forwarding-refs/log-props-after.js
@@ -17,7 +17,7 @@ function logProps(Component) {
 
   // 注意 React.forwardRef 回调的第二个参数 “ref”。
   // 我们可以将其作为常规 prop 属性传递给 LogProps，例如 “forwardedRef”
-  // 然后它就可以被挂载到被 LogPros 包裹的子组件上。
+  // 然后它就可以被挂载到被 LogProps 包裹的子组件上。
   // highlight-range{1-3}
   return React.forwardRef((props, ref) => {
     return <LogProps {...props} forwardedRef={ref} />;


### PR DESCRIPTION
change LogPros to LogProps



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
