### PR TITLE
docs(cn): fix word in content/docs/forwarding-refs.md

### DIFF
--- a/content/docs/forwarding-refs.md
+++ b/content/docs/forwarding-refs.md
@@ -27,7 +27,7 @@ React 组件隐藏其实现细节，包括其渲染结果。其他使用 `FancyB
 
 1. 我们通过调用 `React.createRef` 创建了一个 [React ref](/docs/refs-and-the-dom.html) 并将其赋值给 `ref` 变量。
 1. 我们通过指定 `ref` 为 JSX 属性，将其向下传递给 `<FancyButton ref={ref}>`。
-1. React 传递 `ref` 给 `fowardRef` 内函数 `(props, ref) => ...`，作为其第二个参数。
+1. React 传递 `ref` 给 `forwardRef` 内函数 `(props, ref) => ...`，作为其第二个参数。
 1. 我们向下转发该 `ref` 参数到 `<button ref={ref}>`，将其指定为 JSX 属性。
 1. 当 ref 挂载完成，`ref.current` 将指向 `<button>` DOM 节点。
 


### PR DESCRIPTION

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
