### PR TITLE
docs(cn): translate mssing part of test render

### DIFF
--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -124,7 +124,7 @@ act(() => {
   root = create(<App value={1}/>)
 });
 
-// 比较根结点
+// 比较根元素
 expect(root.toJSON()).toMatchSnapshot();
 
 // 更新 props
@@ -132,7 +132,7 @@ act(() => {
   root = root.update(<App value={2}/>);
 })
 
-// 比较根结点
+// 比较根元素
 expect(root.toJSON()).toMatchSnapshot();
 ```
 

--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -123,7 +123,7 @@ act(() => {
   root = create(<App value={1}/>)
 });
 
-// 比较根元素
+// 对根元素进行断言
 expect(root.toJSON()).toMatchSnapshot();
 
 // 更新 props
@@ -131,7 +131,7 @@ act(() => {
   root = root.update(<App value={2}/>);
 })
 
-// 比较根元素
+// 对根元素进行断言
 expect(root.toJSON()).toMatchSnapshot();
 ```
 

--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -111,8 +111,7 @@ TestRenderer.create(element, options);
 TestRenderer.act(callback);
 ```
 
-与 [`react-dom/test-utils` 中的 `act()`](/docs/test-utils.html#act) 相似，`TestRender.act` 为断言准备一个组件。可以使用 `act()`
-来包装 `TestRenderer.create` 和 `testRenderer.update`。
+与 [`react-dom/test-utils` 中的 `act()`](/docs/test-utils.html#act) 相似，`TestRender.act` 为断言准备一个组件。可以使用 `act()` 来包装 `TestRenderer.create` 和 `testRenderer.update`。
 
 ```javascript
 import {create, act} from 'react-test-renderer';

--- a/content/docs/reference-test-renderer.md
+++ b/content/docs/reference-test-renderer.md
@@ -111,27 +111,28 @@ TestRenderer.create(element, options);
 TestRenderer.act(callback);
 ```
 
-Similar to the [`act()` helper from `react-dom/test-utils`](/docs/test-utils.html#act), `TestRenderer.act` prepares a component for assertions. Use this version of `act()` to wrap calls to `TestRenderer.create` and `testRenderer.update`.
+与 [`react-dom/test-utils` 中的 `act()`](/docs/test-utils.html#act) 相似，`TestRender.act` 为断言准备一个组件。可以使用 `act()`
+来包装 `TestRenderer.create` 和 `testRenderer.update`。
 
 ```javascript
 import {create, act} from 'react-test-renderer';
 import App from './app.js'; // The component being tested
 
-// render the component
+// 渲染组件
 let root; 
 act(() => {
   root = create(<App value={1}/>)
 });
 
-// make assertions on root 
+// 比较根结点
 expect(root.toJSON()).toMatchSnapshot();
 
-// update with some different props
+// 更新 props
 act(() => {
   root = root.update(<App value={2}/>);
 })
 
-// make assertions on root 
+// 比较根结点
 expect(root.toJSON()).toMatchSnapshot();
 ```
 


### PR DESCRIPTION
translate the missing part of content/docs/reference-test-renderer.md



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
