### PR TITLE
docs(cn): fix errors in content/docs/hooks-reference.md

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -239,7 +239,7 @@ function ThemedButton() {
 }
 ```
 
-对先前 [Context 高级指南](/docs/context.md)中的示例使用 hook 进行了修改，你可以在链接中找到有关如何 Context 的更多信息。
+对先前 [Context 高级指南](/docs/context.html)中的示例使用 hook 进行了修改，你可以在链接中找到有关如何 Context 的更多信息。
 
 ## 额外的 Hook {#additional-hooks}
 


### PR DESCRIPTION
fix Page Not Found
[Hook API 索引](https://zh-hans.reactjs.org/docs/hooks-reference.html#usecontext)



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
