### PR TITLE
optimize Font Rendering forFireFox on Linux

### DIFF
--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -1,9 +1,8 @@
 html {
   box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont,
-    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
-    "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+    "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell","Noto Sans CJk SC",sans-serif,
+    "Fira Sans", "Droid Sans", "Helvetica Neue";
   font-weight: 400;
   font-style: normal;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
当前的font-family会导致Linux平台（非Ubuntu）的Firefox浏览器直接选中Droid Sans字体，导致中文显示异常。
