### PR TITLE
Change Chinese translation

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -278,7 +278,7 @@ this.setState(partialState);
 
 ## 受控输入空值 {#controlled-input-null-value}
 
-在[受控组件](/docs/forms.html#controlled-components)上指定 value 的 prop 可以防止用户更改输入。如果指定了 `value`，但输入仍可编辑，则可能是意外地将`value` 设置为  `undefined` 或 `null`。
+在[受控组件](/docs/forms.html#controlled-components)上指定 value 的 prop 会阻止用户更改输入。如果你指定了 `value`，但输入仍可编辑，则可能是你意外地将`value` 设置为  `undefined` 或 `null`。
 
 下面的代码演示了这一点。（输入最初被锁定，但在短时间延迟后变为可编辑。）
 


### PR DESCRIPTION
英文: `Specifying the value prop on a controlled component prevents the user from changing the input unless you desire so. If you’ve specified a value but the input is still editable, you may have accidentally set value to undefined or null.`
把“可以防止”改成“会阻止“，这更容易理解。
原文中的”你“不该省略。这里的”你“就强调读这段文字的人。