### PR TITLE
docs(cn): remove wrong tralation in content/tutorial/tutorial.md

### DIFF
--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -375,7 +375,7 @@ class Board extends React.Component {
   }
 ```
 
-当我们填充棋盘后，`this.state.squares` 数组的值可能像下面这样：
+当我们填充棋盘后，`this.state.squares` 数组的值可能如下所示：
 
 ```javascript
 [

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -375,7 +375,7 @@ class Board extends React.Component {
   }
 ```
 
-当我们填满整个棋盘时，`this.state.squares` 数组的值如下所示：
+当我们填充棋盘后，`this.state.squares` 数组的值可能像下面这样：
 
 ```javascript
 [


### PR DESCRIPTION
`this.state.squares`数组并未填满，官方英文文档也没有说填满

```
When we fill the board in later, the this.state.squares array will look something like this
```
翻译成下面这样会好点，我看文档的时候尬住了/(ㄒoㄒ)/~~
```
当我们填充棋盘后，`this.state.squares` 数组的值可能像下面这样：
```

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
