### PR TITLE
fix: quote mark error in content/docs/forms.md

### DIFF
--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -192,7 +192,7 @@ class FlavorForm extends React.Component {
 
 ## 文件 input 标签 {#the-file-input-tag}
 
-在 HTML 中，`<input type=“file”>` 允许用户从存储设备中选择一个或多个文件，将其上传到服务器，或通过使用 JavaScript 的 [File API](https://developer.mozilla.org/en-US/docs/Web/API/File/Using_files_from_web_applications) 进行控制。
+在 HTML 中，`<input type="file">` 允许用户从存储设备中选择一个或多个文件，将其上传到服务器，或通过使用 JavaScript 的 [File API](https://developer.mozilla.org/en-US/docs/Web/API/File/Using_files_from_web_applications) 进行控制。
 
 ```html
 <input type="file" />


### PR DESCRIPTION
Double quotation marks in English here
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
