### PR TITLE
docs: modify comments

### DIFF
--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -137,8 +137,8 @@ class Parent extends React.Component {
 }
 
 function Child() {
-  // 这个按钮的点击事件会冒泡到父元素
-  // 因为这里没有定义 'onClick' 属性
+  // 这个按钮的点击事件会冒泡到 <Parent/> 组件返回的 DOM 层级中的父元素
+  // 除非在这里定义 'onClick' 属性并阻止事件冒泡
   return (
     <div className="modal">
       <button>Click</button>


### PR DESCRIPTION
1. 注释第一行不容易让读者理解是哪里的 “父元素”，故做明确解释；
2. 注释第二行的内容与 “会冒泡到指定父元素” 这个行为无关，容易给读者带来 ”只要 Child 组件中也添加了 onClick 事件就不会冒泡到父元素“ 的错误认知。