### PR TITLE
docs(cn): fix word in content/docs/context.md

### DIFF
--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -191,7 +191,7 @@ class MyClass extends React.Component {
 
 一个 React 组件可以订阅 context 的变更，这让你在[函数式组件](/docs/components-and-props.html#function-and-class-components)中可以订阅 context。
 
-这种方法需要一个[函数作为子元素（function as a child）](/docs/render-props.html#using-props-other-than-render)。这个函数接收当前的 context 值，并返回一个 React 节点。传递给函数的 `value` 值等等价于组件树上方离这个 context 最近的 Provider 提供的 `value` 值。如果没有对应的 Provider，`value` 参数等同于传递给 `createContext()` 的 `defaultValue`。
+这种方法需要一个[函数作为子元素（function as a child）](/docs/render-props.html#using-props-other-than-render)。这个函数接收当前的 context 值，并返回一个 React 节点。传递给函数的 `value` 值等价于组件树上方离这个 context 最近的 Provider 提供的 `value` 值。如果没有对应的 Provider，`value` 参数等同于传递给 `createContext()` 的 `defaultValue`。
 
 > 注意
 >


### PR DESCRIPTION
194行删除多余的等字

Note to Hacktoberfest 🎃 participants:

While we appreciate the enthusiasm, we are experiencing a high volume of drive-by pull requests (one-line changes, README tweaks, etc.). Please remember that hundreds of people are subscribed to this repo and will receive notifications for these PRs. Spam submissions will be closed and won't count towards your Hacktoberfest goals.

Please search for issues tagged [`good first issue`][gfi] or [`hacktoberfest`][hacktoberfest] to find things to work on.

You can also search [all of GitHub][all].

[gfi]: https://github.com/reactjs/reactjs.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"
[hacktoberfest]: https://github.com/reactjs/reactjs.org/issues?q=is%3Aissue+is%3Aopen+label%3A"good+first+issue"
[all]: https://github.com/search?q=is%3Aissue+hacktoberfest
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
