### PR TITLE
docs(cn): fix word in content/docs/render-props.md

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -321,4 +321,4 @@ class MouseTracker extends React.Component {
 }
 ```
 
-如果你无法静态定义 prop（例如，因为你需要关闭组件的 props 和/或 state），则 `<Mouse>` 应该扩展 `React.Component`。
+如果你无法静态定义 prop（例如，因为你需要关闭组件的 props 和/或 state），则 `<Mouse>` 应该继承自 `React.Component`。


### PR DESCRIPTION
It's more appropriate to translate "extend" into "继承" rather than "扩展" .

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
