### PR TITLE
docs(cn): fix words content/docs/render-props.md

### DIFF
--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -321,4 +321,4 @@ class MouseTracker extends React.Component {
 }
 ```
 
-如果你无法静态定义 prop（例如，因为你需要关闭组件的 props 和/或 state），则 `<Mouse>` 应该继承自 `React.Component`。
+如果你无法静态定义 prop（例如，因为你需要控制组件 props 和/或 state 的暴露程度），则 `<Mouse>` 应该继承自 `React.Component`。


### PR DESCRIPTION
原文是"close over",有"掩盖"的意思,例子将直接暴露的state改为了只暴露需要的state,因此翻译为"控制暴露程度"更便于理解

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
