### PR TITLE
docs(cn): fix translation for persisit

### DIFF
--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -402,7 +402,7 @@ const memoizedValue = useMemo(() => computeExpensiveValue(a, b), [a, b]);
 const refContainer = useRef(initialValue);
 ```
 
-`useRef` 返回一个可变的 ref 对象，其 `.current` 属性被初始化为传入的参数（`initialValue`）。返回的 ref 对象在组件的整个生命周期内保持不变。
+`useRef` 返回一个可变的 ref 对象，其 `.current` 属性被初始化为传入的参数（`initialValue`）。返回的 ref 对象在组件的整个生命周期内持续存在。
 
 一个常见的用例便是命令式地访问子组件：
 


### PR DESCRIPTION
original doc says:`The returned object will persist for the full lifetime of the component.`, emphasize **"persist"**

but the word `保持不变` means `"stay unchanged"` which is inappropriate under the circumstances

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
