### PR TITLE
docs(cn): add link to falsy expressions but do not translate

### DIFF
--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,7 +152,7 @@ ReactDOM.render(
 
 因此，如果条件是 `true`，`&&` 右侧的元素就会被渲染，如果是 `false`，React 会忽略并跳过它。
 
-请注意，[falsy表达式](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)会使 `&&` 后面的元素被跳过，但会返回 falsy表达式的值。在下面示例中，render 方法的返回值是 `<div>0</div>`。
+请注意，[falsy 表达式](https://developer.mozilla.org/en-US/docs/Glossary/Falsy) 会使 `&&` 后面的元素被跳过，但会返回 falsy 表达式的值。在下面示例中，render 方法的返回值是 `<div>0</div>`。
 
 ```javascript{2,5}
 render() {

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -152,7 +152,7 @@ ReactDOM.render(
 
 因此，如果条件是 `true`，`&&` 右侧的元素就会被渲染，如果是 `false`，React 会忽略并跳过它。
 
-请注意，返回 false 的表达式会使 `&&` 后面的元素被跳过，但会返回 false 表达式。在下面示例中，render 方法的返回值是 `<div>0</div>`。
+请注意，[falsy表达式](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)会使 `&&` 后面的元素被跳过，但会返回 falsy表达式的值。在下面示例中，render 方法的返回值是 `<div>0</div>`。
 
 ```javascript{2,5}
 render() {


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
