### PR TITLE
docs(cn): fix a confusing statement

### DIFF
--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -431,7 +431,7 @@ function ListOfTenThings() {
 </div>
 ```
 
-值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 `0`，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，因为当 `props.messages` 是空数组时，会渲染出数字 `0`：
+值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 `0`，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，因为当 `props.messages` 是空数组时，将会渲染为数字 `0`：
 
 ```js{2}
 <div>

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -431,7 +431,7 @@ function ListOfTenThings() {
 </div>
 ```
 
-值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 `0`，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，因为当 `props.messages` 是空数组时，`0` 仍然会被渲染：
+值得注意的是有一些 ["falsy" 值](https://developer.mozilla.org/en-US/docs/Glossary/Falsy)，如数字 `0`，仍然会被 React 渲染。例如，以下代码并不会像你预期那样工作，因为当 `props.messages` 是空数组时，会渲染出数字 `0`：
 
 ```js{2}
 <div>


### PR DESCRIPTION
The English version:
For example, this code will not behave as you might expect because 0 will be printed when props.messages is an empty array:

The Chineses version:
例如，以下代码并不会像你预期那样工作，因为当 props.messages 是空数组时，0 仍然会被渲染：


呃，讲中文吧。
上一段示例在讲`{showHeader && <Header />}`，到这一段来个`仍然会被渲染`，还以为讲的是`MessageList`组件仍然会被渲染，容易理解错

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
