### PR TITLE
fix(cn): description error

### DIFF
--- a/beta/src/content/learn/scaling-up-with-reducer-and-context.md
+++ b/beta/src/content/learn/scaling-up-with-reducer-and-context.md
@@ -215,7 +215,6 @@ ul, li { margin: 0; padding: 0; }
 Reducer 有助于保持事件处理程序的简短明了。但随着应用规模越来越庞大，你就可能会遇到别的困难。**目前，`tasks` 状态和 `dispatch` 函数仅在顶级 `TaskApp` 组件中可用**。要让其他组件读取任务列表或更改它，你必须显式 [传递](/learn/passing-props-to-a-component) 当前状态和将其更改为 props 的事件处理程序。
 
 例如，`TaskApp` 将 一系列 task 和事件处理程序传递给 `TaskList`：
-For example, `TaskApp` passes a list of tasks and the event handlers to `TaskList`:
 
 ```js
 <TaskList


### PR DESCRIPTION
之前这个地方忘记删英文了。

更改前：
例如，TaskApp 将 一系列 task 和事件处理程序传递给 TaskList：
For example, TaskApp passes a list of tasks and the event handlers to TaskList:

更改后：
例如，TaskApp 将 一系列 task 和事件处理程序传递给 TaskList：