### PR TITLE
fix(cn): lack of translation

### DIFF
--- a/beta/src/content/learn/extracting-state-logic-into-a-reducer.md
+++ b/beta/src/content/learn/extracting-state-logic-into-a-reducer.md
@@ -467,13 +467,13 @@ export default function tasksReducer(tasks, action) {
 import {useReducer} from 'react';
 ```
 
-Then you can replace `useState`:
+接下来，你就可以替换掉之前的 `useState`:
 
 ```js
 const [tasks, setTasks] = useState(initialTasks);
 ```
 
-with `useReducer` like so:
+只需要像下面这样使用 `useReducer`:
 
 ```js
 const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);


### PR DESCRIPTION
这两句话是不是翻译时漏掉了，简单翻译了一下不知道是否合适。

### 更改前：

Then you can replace `useState`:

```js
const [tasks, setTasks] = useState(initialTasks);
```

with `useReducer` like so:

```js
const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);
```

### 更改后：

接下来，你就可以替换掉之前的 `useState`:

```js
const [tasks, setTasks] = useState(initialTasks);
```

只需要像下面这样使用 `useReducer`:

```js
const [tasks, dispatch] = useReducer(tasksReducer, initialTasks);
```