### PR TITLE
fit(cn): lack of translation

### DIFF
--- a/beta/src/content/learn/writing-markup-with-jsx.md
+++ b/beta/src/content/learn/writing-markup-with-jsx.md
@@ -41,7 +41,7 @@ JavaScript
 
 </DiagramGroup>
 
-But as the Web became more interactive, logic increasingly determined content. JavaScript was in charge of the HTML! This is why **in React, rendering logic and markup live together in the same place—components.**
+但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，将标记和渲染逻辑耦合在同一个地方 —— 组件。**
 
 <DiagramGroup>
 

--- a/beta/src/content/learn/writing-markup-with-jsx.md
+++ b/beta/src/content/learn/writing-markup-with-jsx.md
@@ -41,7 +41,7 @@ JavaScript
 
 </DiagramGroup>
 
-但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，将标记和渲染逻辑耦合在同一个地方 —— 组件。**
+但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，渲染逻辑和标记耦合在同一个地方 —— 组件。**
 
 <DiagramGroup>
 

--- a/beta/src/content/learn/writing-markup-with-jsx.md
+++ b/beta/src/content/learn/writing-markup-with-jsx.md
@@ -41,7 +41,7 @@ JavaScript
 
 </DiagramGroup>
 
-但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，渲染逻辑和标记耦合在同一个地方 —— 组件。**
+但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，渲染逻辑和标记共同存在于同一个地方 —— 组件。**
 
 <DiagramGroup>
 

--- a/beta/src/content/learn/writing-markup-with-jsx.md
+++ b/beta/src/content/learn/writing-markup-with-jsx.md
@@ -41,7 +41,7 @@ JavaScript
 
 </DiagramGroup>
 
-但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，渲染逻辑和标记共同存在于同一个地方 —— 组件。**
+但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 负责 HTML 的内容！这也是为什么 **在 React 中，渲染逻辑和标记共同存在于同一个地方——组件。**
 
 <DiagramGroup>
 


### PR DESCRIPTION
有一小段内容没有翻译，不知是不是被遗漏了，简单进行了一下翻译不知道合不合适。

更改前：
But as the Web became more interactive, logic increasingly determined content. JavaScript was in charge of the HTML! This is why **in React, rendering logic and markup live together in the same place—components.**

更改后：
但随着 Web 的交互性越来越强，逻辑越来越决定页面中的内容。JavaScript 需要对 HTML 负责！这也是为什么 **在 React 中，渲染逻辑和标记共同存在于同一个地方——组件。**