### PR TITLE
fix(cn): lack of translation in writing-markup-with-jsx.md

### DIFF
--- a/beta/src/content/learn/writing-markup-with-jsx.md
+++ b/beta/src/content/learn/writing-markup-with-jsx.md
@@ -41,7 +41,7 @@ JavaScript
 
 </DiagramGroup>
 
-But as the Web became more interactive, logic increasingly determined content. JavaScript was in charge of the HTML! This is why **in React, rendering logic and markup live together in the same place—components.**
+但随着网络越来越具有交互性，逻辑也决定了内容的产生。JavaScript负责HTML！这就是为什么**在React中，渲染逻辑和标记都在同一个地方——组件。**
 
 <DiagramGroup>
 


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

<img width="930" alt="Screen Shot 2022-11-20 at 16 12 57" src="https://user-images.githubusercontent.com/47740312/202892236-e6596e40-81f0-4bfc-b876-7c4810aa6986.png">


writing-markup-with-jsx.md 文档中有英文没有翻译



