### PR TITLE
fix(cn): sentences that are not translated

### DIFF
--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -92,7 +92,7 @@ class Toggle extends React.Component {
 
 这并不是 React 特有的行为；这其实与 [JavaScript 函数工作原理](https://www.smashingmagazine.com/2014/01/understanding-javascript-function-prototype-bind/)有关。通常情况下，如果你没有在方法后面添加 `()`，例如 `onClick={this.handleClick}`，你应该为这个方法绑定 `this`。
 
-如果觉得使用 `bind` 很麻烦，这里有两种方式可以解决。你可以使用 [public class fields 语法](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields#public_instance_fields) to correctly bind callbacks:
+如果觉得使用 `bind` 很麻烦，这里有两种方式可以解决。你可以使用 [public class fields 语法](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields#public_instance_fields) 来正确地绑定回调函数:
 
 ```js{2-6}
 class LoggingButton extends React.Component {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39086666/216935232-cbe1b533-9c5a-456f-93ba-5335cfd12b9e.png)

有半句话没有被翻译

你可以使用public class fields 语法 to correctly bind callbacks ---> 你可以使用public class fields 语法来正确地绑定回调函数