### PR TITLE
fix: add missing link

### DIFF
--- a/src/content/reference/react-dom/components/link.md
+++ b/src/content/reference/react-dom/components/link.md
@@ -4,7 +4,7 @@ link: "<link>"
 
 <Intro>
 
-浏览器内置的 `<link>` 组件允许使用外部资源，例如样式表，或使用链接元数据注释文档。
+[浏览器内置的 `<link>` 组件](https://developer.mozilla.org/zh-CN/docs/Web/HTML/Element/link) 允许使用外部资源，例如样式表，或使用链接元数据注释文档。
 
 ```js
 <link rel="icon" href="favicon.ico" />


### PR DESCRIPTION
https://react.dev/reference/react-dom/components/link
参考英文文档，此处应有链接。
