### PR TITLE
docs: Fix dead link and update zh vesion link sunsetting-create-react…

### DIFF
--- a/src/content/blog/2025/02/14/sunsetting-create-react-app.md
+++ b/src/content/blog/2025/02/14/sunsetting-create-react-app.md
@@ -280,7 +280,7 @@ const router = createBrowserRouter([
 
 #### 服务器端渲染是可选的 {/*server-rendering-is-optional*/}
 
-我们推荐的框架都提供了创建 [客户端渲染（CSR）](https://developer.mozilla.org/en-US/docs/Glossary/CSR) 应用的选项。
+我们推荐的框架都提供了创建 [客户端渲染（CSR）](https://developer.mozilla.org/zh-CN/docs/Glossary/CSR) 应用的选项。
 
 在某些情况下，客户端渲染（CSR）对于某个页面来说是正确的选择，但很多时候并非如此。即使你的应用大部分采用客户端渲染，通常也会有一些单独的页面能够从服务器端渲染特性中获益，比如 [静态网站生成（SSG）](https://developer.mozilla.org/zh-CN/docs/Glossary/SSG) 或 [服务器端渲染（SSR）](https://developer.mozilla.org/zh-CN/docs/Glossary/SSR)，例如服务条款页面或文档页面。
 


### PR DESCRIPTION
## [update zh version](https://zh-hans.react.dev/blog/2025/02/14/sunsetting-create-react-app#how-to-migrate-to-a-framework)
<img width="1278" height="407" alt="image" src="https://github.com/user-attachments/assets/6bfc5a39-2536-41d0-a9b8-bd13fdf24985" />

have zh version
<img width="1519" height="498" alt="image" src="https://github.com/user-attachments/assets/3e87c87d-d5bb-4905-9962-79523fbed043" />

## [dead link](https://zh-hans.react.dev/blog/2025/02/14/sunsetting-create-react-app#why-we-recommend-frameworks)
<img width="1223" height="663" alt="image" src="https://github.com/user-attachments/assets/d845a6ed-d886-4325-af96-9365dd7b68d2" />

open after
<img width="1299" height="549" alt="image" src="https://github.com/user-attachments/assets/b73bfb2e-f329-4af8-b379-d0490755906f" />

