### PR TITLE
fix: Fix translation errors in useTransition

### DIFF
--- a/src/content/reference/react/useTransition.md
+++ b/src/content/reference/react/useTransition.md
@@ -1717,7 +1717,7 @@ startTransition(async () => {
 ```js
 startTransition(async () => {
   await someAsyncFunction();
-  // ✅ 在 startTransition **之后** 再 await
+  // ✅ 在 await 之后 调用 startTransition
   startTransition(() => {
     setPage('/about');
   });


### PR DESCRIPTION
[原文](https://github.com/reactjs/react.dev/blob/f8c81a0f4f8e454c850f0c854ad054b32313345c/src/content/reference/react/useTransition.md?plain=1#L1720)是`  // ✅ Using startTransition *after* await`