### PR TITLE
docs: Update title from 'Directives' to '指令符'

### DIFF
--- a/src/sidebarReference.json
+++ b/src/sidebarReference.json
@@ -519,7 +519,7 @@
       "path": "/reference/rsc/server-functions"
     },
     {
-      "title": "Directives",
+      "title": "指令符",
       "path": "/reference/rsc/directives",
       "routes": [
         {


### PR DESCRIPTION
Fix documentation translation

The sidebar translation is incomplete